### PR TITLE
[조혜진] 가게 정보 상세 페이지 구현 및 편집 페이지 연결

### DIFF
--- a/api/data.tsx
+++ b/api/data.tsx
@@ -4,7 +4,7 @@ import React from "react";
 const PostNotice: React.FC = () => {
   const postNotice = async () => {
     const url =
-      "https://bootcamp-api.codeit.kr/api/0-1/the-julge/shops/75cd4be7-cfa9-48b9-b7c9-2ee070512bc5/notices";
+      "https://bootcamp-api.codeit.kr/api/0-1/the-julge/shops/d10c2dde-84bd-4d81-a4e9-387a09db8fff/notices";
 
     const accessToken = localStorage.getItem("accessToken");
     const data = {

--- a/api/myShop.ts
+++ b/api/myShop.ts
@@ -11,9 +11,20 @@ export const submitShopForm = async (formData: FormData) => {
         Authorization: `Bearer ${accessToken}`,
       },
     });
-    return response.data;
+    return response;
   } catch (error) {
     console.error("Shop form submission error:", error);
+    throw error;
+  }
+};
+
+export const fetchShopData = async (shopId: string) => {
+  try {
+    const response = await axios.get(`${BASE_URL}/shops/${shopId}`);
+    console.log(response);
+    return response;
+  } catch (error) {
+    console.error("Shop data fetching failed:", error);
     throw error;
   }
 };

--- a/components/Shop/Shop.types.ts
+++ b/components/Shop/Shop.types.ts
@@ -5,7 +5,8 @@ export interface ShopEmptyProps {
 }
 
 export interface ShopFormProps {
-  onClose: () => void;
+  onClose?: () => void;
+  onEdit?: () => void;
 }
 
 export interface FormData {

--- a/components/Shop/ShopForm/index.tsx
+++ b/components/Shop/ShopForm/index.tsx
@@ -58,7 +58,7 @@ const ShopForm: React.FC<ShopFormProps> = ({ onClose }) => {
 
     try {
       const response = await submitShopForm(formData);
-      if (response.ok) {
+      if (response.status === 200) {
         setModalData({
           modalType: "alert",
           content: "등록이 완료되었습니다.",

--- a/components/Shop/ShopNotice/index.tsx
+++ b/components/Shop/ShopNotice/index.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import styles from "../ShopView/ShopView.module.scss";
+import classNames from "classnames/bind";
+import Button from "@/components/Button";
+
+const cx = classNames.bind(styles);
+
+const ShopNotice = () => {
+  return (
+    <div className={cx("container")}>
+      <div className={cx("header")}>
+        <h1 className={cx("title")}>등록한 공고</h1>
+      </div>
+      <div className={cx("notice")}>
+        <div className={cx("notice-wrapper")}>
+          <p>공고를 등록해 보세요.</p>
+          <Button btnColorType="orange" btnCustom="userNoticeDetailed">
+            공고 등록하기
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShopNotice;

--- a/components/Shop/ShopView/ShopView.module.scss
+++ b/components/Shop/ShopView/ShopView.module.scss
@@ -1,0 +1,172 @@
+@import "@/styles/const.scss";
+
+@mixin flex-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.profile {
+  width: 100%;
+  @include flex-column;
+  align-items: center;
+
+  @media (max-width: $TABLET) {
+    padding: 40px 32px;
+    flex-direction: column;
+  }
+
+  @media (max-width: $MOBILE) {
+    padding: 40px 12px;
+    flex-direction: column;
+  }
+}
+
+.notice-list {
+  background-color: var(--gray5);
+}
+
+.container {
+  width: 964px;
+  padding: 60px 0;
+
+  @media (max-width: $TABLET) {
+    width: 100%;
+    padding: 0 0 60px 0;
+  }
+}
+
+.header {
+  width: 30%;
+}
+
+.title {
+  font-size: 28px;
+  font-weight: 700;
+  margin-bottom: 20px;
+
+  @media (max-width: $MOBILE) {
+    font-size: 20px;
+  }
+}
+.info-wrapper {
+  width: 100%;
+  height: 356px;
+  background-color: var(--red10);
+  border-radius: 12px;
+  padding: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  @media (max-width: $TABLET) {
+    width: 100%;
+    height: 677px;
+    flex-direction: column;
+  }
+
+  @media (max-width: $MOBILE) {
+    height: 450px;
+  }
+}
+.info {
+  @include flex-column;
+  width: 346px;
+  height: 100%;
+  justify-content: space-between;
+  padding-top: 16px;
+
+  @media (max-width: $TABLET) {
+    width: 100%;
+  }
+}
+.details {
+  @include flex-column;
+  gap: 12px;
+}
+.detail-name {
+  @include flex-column;
+  gap: 12px;
+}
+.name-section {
+  @include flex-column;
+  gap: 8px;
+}
+.name {
+  color: var(--primary);
+  font-size: 16px;
+  font-weight: 700;
+}
+.my-name {
+  font-weight: 700;
+  font-size: 28px;
+}
+.detail {
+  color: var(--gray50);
+  display: flex;
+  gap: 6px;
+}
+.notice-info__img {
+  position: relative;
+  width: 539px;
+  height: 308px;
+  border-radius: 12px;
+  overflow: hidden;
+
+  @media (max-width: $TABLET) {
+    width: 100%;
+    height: 100%;
+  }
+}
+.bio {
+  height: 100%;
+  font-size: 16px;
+  font-weight: 400;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    scrollbar-width: 4px;
+    background-color: #7d7986;
+    border-radius: 4px;
+  }
+}
+.button-wrapper {
+  width: 100%;
+  display: flex;
+  gap: 8px;
+}
+.notice {
+  width: 964px;
+  height: 217px;
+  border: 1px solid var(--gray20);
+  border-radius: 12px;
+  padding: 60px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  @media (max-width: $TABLET) {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  @media (max-width: $MOBILE) {
+  }
+}
+
+.notice-wrapper {
+  width: 346px;
+  gap: 24px;
+  @include flex-column;
+  align-items: center;
+
+  @media (max-width: $TABLET) {
+    flex-direction: column;
+  }
+
+  @media (max-width: $MOBILE) {
+    width: 150px;
+  }
+}

--- a/components/Shop/ShopView/index.tsx
+++ b/components/Shop/ShopView/index.tsx
@@ -1,27 +1,85 @@
+import React, { useEffect, useState } from "react";
+import styles from "./ShopView.module.scss";
 import classNames from "classnames/bind";
-import styles from "../Shop.module.scss";
+import Button from "@/components/Button";
 import Image from "next/image";
-import { ShopFormProps } from "../Shop.types";
+import { FormData, ShopFormProps } from "../Shop.types";
+import { fetchShopData } from "@/api/myShop";
+import { useRecoilValue } from "recoil";
+import Spinner from "@/components/Spinner";
+import { employerAtom } from "@/atoms/employerAtom";
+import ShopNotice from "../ShopNotice";
 
 const cx = classNames.bind(styles);
 
-const ShopView: React.FC<ShopFormProps> = ({ onClose }) => {
+const ShopView: React.FC<ShopFormProps> = ({ onEdit }) => {
+  const [shopData, setShopData] = useState<FormData | null>(null);
+  const shopValue = useRecoilValue(employerAtom);
+
+  useEffect(() => {
+    const fetchAndSetShopData = async () => {
+      if (shopValue) {
+        try {
+          const response = await fetchShopData(shopValue.shopId);
+          setShopData(response.data.item);
+        } catch (error) {
+          console.error("Fetching shop data failed:", error);
+        }
+      }
+    };
+
+    fetchAndSetShopData();
+  }, [shopValue]);
+
+  if (!shopData) {
+    return (
+      <div>
+        <Spinner />
+      </div>
+    );
+  }
+
   return (
-    <div className={cx("container")}>
-      <main className={cx("profile", "main")}>
+    <div className={cx("profile")}>
+      <div className={cx("container")}>
         <div className={cx("header")}>
-          <h1 className={cx("title")}>가게 정보</h1>
-          <Image
-            src="/image/icon/shop_close.svg"
-            width={32}
-            height={32}
-            alt="close button"
-            onClick={onClose}
-            className={cx("close-button")}
-          />
+          <h1 className={cx("title")}>내 가게</h1>
         </div>
-        <h2>가게 정보 조회 화면 구현 要</h2>
-      </main>
+        <div className={cx("info-wrapper")}>
+          <div className={cx("notice-info__img")}>
+            <Image
+              style={{
+                objectFit: "cover",
+              }}
+              fill
+              src={shopData.imageUrl}
+              alt="가게 이미지"
+            />
+          </div>
+          <div className={cx("info")}>
+            <div className={cx("details")}>
+              <div className={cx("detail-name")}>
+                <p className={cx("name")}>식당</p>
+                <h2 className={cx("my-name")}>{shopData.name}</h2>
+              </div>
+              <div className={cx("detail")}>
+                <Image width={20} height={20} src="/image/icon/location.svg" alt="위치 아이콘" />
+                <p>{shopData.address1}</p>
+              </div>
+              <p className={cx("bio")}>{shopData.description}</p>
+            </div>
+            <div className={cx("button-wrapper")}>
+              <Button btnColorType="white" btnCustom="userNoticeDetailed" onClick={onEdit}>
+                편집하기
+              </Button>
+              <Button btnColorType="orange" btnCustom="userNoticeDetailed">
+                공고 등록하기
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <ShopNotice />
     </div>
   );
 };

--- a/pages/my-shop/index.tsx
+++ b/pages/my-shop/index.tsx
@@ -7,6 +7,7 @@ import axios from "axios";
 import { useState } from "react";
 import { BASE_URL } from "@/constants/constants";
 import ShopView from "@/components/Shop/ShopView";
+import ShopEdit from "@/components/Shop/ShopEdit";
 
 const fetchUserInfo = async (token: string, userId: string) => {
   try {
@@ -24,6 +25,7 @@ const fetchUserInfo = async (token: string, userId: string) => {
 
 const MyShop = () => {
   const [showShopForm, setShowShopForm] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
   const [employer, setEmployer] = useRecoilState(employerAtom);
 
   useEffect(() => {
@@ -56,12 +58,22 @@ const MyShop = () => {
     setShowShopForm(false);
   };
 
+  const handleEditClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleCloseEdit = () => {
+    setIsEditing(false);
+  };
+
   return (
     <>
       {showShopForm ? (
         <ShopForm onClose={handleCloseShopForm} />
+      ) : isEditing ? (
+        <ShopEdit onClose={handleCloseEdit} />
       ) : isShopRegistered ? (
-        <ShopView onClose={handleCloseShopForm} />
+        <ShopView onEdit={handleEditClick} />
       ) : (
         <ShopEmpty onClick={handleShopButtonClick} />
       )}


### PR DESCRIPTION
## 🔎 작업 내용

- [x] 가게 정보 상세 페이지 구현 및 편집 페이지 연결
  <br/>

## 📸 스크린샷
![image](https://github.com/part3-team5/the-julge/assets/57613101/a741bec5-30fe-42c6-b8b6-e69a48ca457c)
![image](https://github.com/part3-team5/the-julge/assets/57613101/468dae73-8428-4447-8fe3-d0db4eb51999)
![image](https://github.com/part3-team5/the-julge/assets/57613101/ec18c27e-3347-4980-9afa-77646f144cc3)


## 💌 리뷰어에게....

- 가게 정보 편집 페이지 구현 예정
- 하단 `등록한 공고` 공고 목록 있을 시 목록 출력 추가 구현 필요